### PR TITLE
Use correct method call when writing to clipboard

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -161,7 +161,7 @@ nova.commands.register(
 
 nova.commands.register(
   "github-shortcuts.copyLinkToFile",
-  (editor) => commandHandler(editor).then((url) => nova.clipboard(url).writeText).catch((error) => nova.workspace.showErrorMessage(error))
+  (editor) => commandHandler(editor).then((url) => nova.clipboard.writeText(url)).catch((error) => nova.workspace.showErrorMessage(error))
 );
 
 nova.commands.register(


### PR DESCRIPTION
This was causing an error when trying to copy a link.

<img width="580" alt="Screen Shot 2021-04-08 at 11 56 48" src="https://user-images.githubusercontent.com/4047861/114058722-b6bcac80-9861-11eb-837c-80bbc23a3d9d.png">
